### PR TITLE
Gaction

### DIFF
--- a/src/GRID4P/Gaction.java
+++ b/src/GRID4P/Gaction.java
@@ -1,0 +1,33 @@
+package grid4p;
+
+/**
+ * An interface for user defined actions to be performed upon the occurrence of certain midi events.
+ * All of the methods are default, so any or none of
+ * them may be implemented or left out without consequence.
+ */
+public interface Gaction {
+    /**
+     * method to be called upon the "pushing down" of a GRID controller element
+     */
+    default void onpush() {
+        Grid.verboseWarning("The user hasn't implemented this method");
+    }
+    /**
+     * method to be called upon the "release" of a GRID controller element
+     */
+    default void onrelease(){
+        Grid.verboseWarning("The user hasn't implemented this method");
+    }
+    /**
+     * method to be called upon any change to the value of a GRID controller element
+     */
+    default void ontweak(){
+        Grid.verboseWarning("The user hasn't implemented this method");
+    }
+    /**
+     * method to be called upon the value of a GRID controller element reaching its maximum or minimum
+     */
+    default void onlimitreached(){
+        Grid.verboseWarning("The user hasn't implemented this method");
+    }
+}

--- a/src/GRID4P/Gknob.java
+++ b/src/GRID4P/Gknob.java
@@ -15,6 +15,7 @@ public class Gknob {
     protected int val, def;
     protected float min, max;
     protected boolean used, button;
+    protected Gaction gaction;
 
     /**
      * Constructor for a Gknob, intended to be called when populating
@@ -122,6 +123,16 @@ public class Gknob {
      */
     private float map(float val, float ax, float ay, float bx, float by){
         return bx + (by - bx) * ((val - ax) / (ay - ax));
+    }
+
+    /**
+     * Method which accepts a user created Gaction object, with user defined gaction methods.
+     * The methods in the Gaction are to be called when the appropriate midi event occurs.
+     *
+     * @param passedAction user defined implementation of the Gaction interface
+     */
+    public void setAction(Gaction passedAction){
+        this.gaction = passedAction;
     }
 }
 

--- a/src/GRID4P/Gknob.java
+++ b/src/GRID4P/Gknob.java
@@ -126,13 +126,15 @@ public class Gknob {
     }
 
     /**
-     * Method which accepts a user created Gaction object, with user defined gaction methods.
+     * Method which accepts a user-implemented Gaction, with user defined gaction methods.
      * The methods in the Gaction are to be called when the appropriate midi event occurs.
      *
      * @param passedAction user defined implementation of the Gaction interface
+     * @return this object. Useful in some instances.
      */
-    public void setAction(Gaction passedAction){
+    public Gknob setGaction(Gaction passedAction){
         this.gaction = passedAction;
+        return this;
     }
 }
 

--- a/src/GRID4P/Grid.java
+++ b/src/GRID4P/Grid.java
@@ -197,6 +197,10 @@ public abstract class Grid {
     protected static void controllerChange(int channel, int number, int value) {
         int n = min(number - NOTE_OFFSET + channel * BANK_MULT, TOTAL_PARAMS - 1);
         k[n].val = value;
+        if(k[n].gaction != null){
+            k[n].gaction.ontweak(); //perform gaction ontweak routine
+            if(k[n].getRaw() <= 0 || k[n].getRaw() >= 127) k[n].gaction.onlimitreached(); // if limit is reached, perform onlimitreached routine
+        }
         midiEventCount++;
         verboseMidiEventMessaging("Tweak",
                 Integer.toString(channel),
@@ -221,6 +225,9 @@ public abstract class Grid {
     protected static void noteOn(int channel, int number, int value) {
         int n = min(number - NOTE_OFFSET + channel * BANK_MULT, TOTAL_PARAMS - 1);
         k[n].button = true;
+        if(k[n].gaction != null){
+            k[n].gaction.onpush();
+        }
         midiEventCount++;
         verboseMidiEventMessaging("Note-On",
                 Integer.toString(channel),
@@ -244,6 +251,9 @@ public abstract class Grid {
     protected static void noteOff(int channel, int number, int value) {
         int n = min(number - NOTE_OFFSET + channel * BANK_MULT, TOTAL_PARAMS - 1);
         k[n].button = false;
+        if(k[n].gaction != null){
+            k[n].gaction.onrelease(); //perform gaction onrelease routine
+        }
         midiEventCount++;
         verboseMidiEventMessaging("Note-Off",
                 Integer.toString(channel),
@@ -281,12 +291,22 @@ public abstract class Grid {
      * @param value midi value
      * @param eventID midi event ID
      */
-    private static void verboseMidiEventMessaging(String eventType, String channel, String number, String value, String eventID){
+    protected static void verboseMidiEventMessaging(String eventType, String channel, String number, String value, String eventID){
         if(verbose){
             System.out.println(eventType + " | Channel: " +
                     channel + " | Number: " +
                     number + " | Value: " +
                     value + " -- EventID: " + eventID);
+        }
+    }
+
+    /**
+     * Another generic method for warnings about the GRID communications that are preferred to be verbose
+     * @param warning String containing warning description
+     */
+    protected static void verboseWarning(String warning){
+        if(verbose){
+            System.out.println(warning);
         }
     }
 

--- a/src/GRID4P/Grid.java
+++ b/src/GRID4P/Grid.java
@@ -339,6 +339,18 @@ public abstract class Grid {
     }
 
     /**
+     * Method which accepts a user-implemented Gaction, with user defined gaction methods.
+     * The methods in the Gaction are to be called when the appropriate midi event occurs.
+     *
+     * @param GknobIndex index of the Gknob to which the Gaction is to be assigned
+     * @param passedAction user defined implementation of the Gaction interface
+     * @return the Gknob which has been assigned the Gaction. Useful in some instances.
+     */
+    private static Gknob setGaction(int GknobIndex, Gaction passedAction){
+        return k[GknobIndex].setGaction(passedAction);
+    }
+
+    /**
      * Auxiliary method for determining the index of the Intech GRID
      * within the recognized midi inputs
      *

--- a/src/GactionTest.java
+++ b/src/GactionTest.java
@@ -14,7 +14,7 @@ public class GactionTest extends PApplet{
         a = Grid.add(0, 1000);
         b = Grid.add(0, height);
         c = Grid.add(0, 5, 1);
-        a.setAction(new Gaction(){
+        a.setGaction(new Gaction(){
             public void onpush(){
                 size = b.get();
             }

--- a/src/GactionTest.java
+++ b/src/GactionTest.java
@@ -2,34 +2,27 @@ import grid4p.*;
 import processing.core.PApplet;
 
 public class GactionTest extends PApplet{
-    Gknob a, b, c;
+    Gknob myGknob;
     float size = 0;
+    int bg = 0;
 
     public void settings(){
         size(500, 500);
     }
     public void setup(){
-
-        Grid.begin();
-        a = Grid.add(0, 1000);
-        b = Grid.add(0, height);
-        c = Grid.add(0, 5, 1);
-        a.setGaction(new Gaction(){
-            public void onpush(){
-                size = b.get();
-            }
-            public void onlimitreached(){
-                background(255, 0, 0);
+        size(500, 500);
+        Grid.begin();  //set up Grid
+        myGknob = Grid.add(0, 500, 250); //add Gknob configuration to the Grid
+        myGknob.setGaction(new Gaction(){ //pass implemented Gaction into the Gknob's setGaction method
+            public void onpush(){ //define whichever methods you'd like
+                size = myGknob.get();
             }
         });
-
-
     }
     public void draw(){
-    background(0);
-    circle(width >> 1, height >> 1, size);
-    if(size > 0) size -= c.get();
-
+        background(0);
+        circle(width >> 1, height >> 1, size);
+        if(size > 0) --size;
     }
 
     public static void main(String[] args){

--- a/src/GactionTest.java
+++ b/src/GactionTest.java
@@ -1,0 +1,40 @@
+import grid4p.*;
+import processing.core.PApplet;
+
+public class GactionTest extends PApplet{
+    Gknob a, b, c;
+    float size = 0;
+
+    public void settings(){
+        size(500, 500);
+    }
+    public void setup(){
+
+        Grid.begin();
+        a = Grid.add(0, 1000);
+        b = Grid.add(0, height);
+        c = Grid.add(0, 5, 1);
+        a.setAction(new Gaction(){
+            public void onpush(){
+                size = b.get();
+            }
+            public void onlimitreached(){
+                background(255, 0, 0);
+            }
+        });
+
+
+    }
+    public void draw(){
+    background(0);
+    circle(width >> 1, height >> 1, size);
+    if(size > 0) size -= c.get();
+
+    }
+
+    public static void main(String[] args){
+        PApplet.main("GactionTest");
+    }
+
+
+}


### PR DESCRIPTION
# Gaction
Adding support for user defined methods to be executed upon appropriate midi events.<br>
Each Gknob has a set of these methods, contained in their own <b>Gaction</b> interface. <br>
All of these methods have default implementations so feel free to implement some or all or none of them. 


Four implementable methods were added: 
- onpush()
- onrelease()
- ontweak()
- onlimitreached()

These are pretty self explanatory but basically:
- the onpush() method will be called when a GRID element gets "pushed down", triggering a "Note On" midi message
- the onrelease() does the opposite, and is called upon the release of a GRID element (aka, "Note Off" midi message)
- the ontweak() gets called whenever there is a controller change of value
- the onlimitreached() is called only when a GRID element is tweaked <b>and</b> its value is at its upper or lower limit. (in the case that the method is called, it gets called <b>after</b> the ontweak() method)

## Example
<pre>import grid4p.*;
Gknob myGknob;
int size = 0;

public void setup(){
  size(500, 500);
  Grid.begin();  //set up Grid
  myGknob = Grid.add(0, 500, 250); //add Gknob configuration to the Grid
  myGknob.setGaction(new Gaction(){ //pass implemented Gaction into the Gknob's setGaction method
    public void onpush(){ //define whichever methods you'd like
      size = myGknob.get(); //for example, our function will assign the sketch's "size" variable to the value held by the myGknob
    }
  });
}

public void draw(){
  background(0);
  circle(width >> 1, height >> 1, size);
  if(size > 0) --size; //constantly decrease size
}
</pre>
